### PR TITLE
fix: correct critical typo in README - Changed 'implimentation' to 'implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This is the project implimentation document.
+This is the project implementation document.


### PR DESCRIPTION
This was causing confusion for users.
